### PR TITLE
ENH: process recovered scans

### DIFF
--- a/aux/merge_biographies
+++ b/aux/merge_biographies
@@ -120,7 +120,7 @@ foreach( $host_list as $host_item )
       'OR '.
       '(rank=1 AND pass IS NOT NULL AND status IN ("completed","exported"))'.
     ') '.
-    'AND availability=1 '.
+    'AND invalid=0 '.
     'AND scanid IS NOT NULL '.
     'AND patient_key IS NOT NULL '.
     'AND scan_datetime IS NOT NULL '.
@@ -167,7 +167,7 @@ foreach( $host_list as $host_item )
         'join apex_baseline b on b.id=e.apex_baseline_id '.
         'join %scenozo.participant p on p.id=b.participant_id '.
         'where type="%s" '.
-        'and availability=1 '.
+        'and (availability=1 or invalid=0) '.
         'and side="%s" '.
         'and apex_baseline_id=%d '.
         'group by uid',
@@ -187,7 +187,7 @@ foreach( $host_list as $host_item )
           'join apex_host h on h.id=d.apex_host_id '.
           'join %scenozo.participant p on p.id=b.participant_id '.
           'where type="%s" '.
-          'and availability=1 '.
+          'and invalid=0 '.
           'and side="%s" '.
           'and apex_baseline_id=%d '.
           'and rank=%d',

--- a/aux/process_requests
+++ b/aux/process_requests
@@ -244,7 +244,7 @@ if( null !== $deployment_id )
     'JOIN apex_baseline b ON b.id=e.apex_baseline_id '.
     'JOIN %scenozo.participant p ON p.id=b.participant_id '.
     'JOIN %scenozo.language l ON l.id=p.language_id '.
-    'WHERE availability=1 '.
+    'WHERE invalid=0 '.
     'AND t.type in ("hip") '.
     'AND export_filename IS NOT NULL '.
     'AND pass=1 '.
@@ -298,7 +298,7 @@ foreach( $host_list as $host_item )
     'JOIN apex_baseline b ON b.id=e.apex_baseline_id '.
     'JOIN %scenozo.participant p ON p.id=b.participant_id '.
     'JOIN %scenozo.language l ON l.id=p.language_id '.
-    'WHERE availability=1 '.
+    'WHERE invalid=0 '.
     'AND export_filename IS NOT NULL '.
     'AMD type in ("hip") '.
     'AND pass=1 '.

--- a/aux/push_salix_meta
+++ b/aux/push_salix_meta
@@ -226,7 +226,7 @@ foreach( $host_list as $host_item )
     'AND s.scan_datetime IS NOT NULL '.
     'AND s.scanid IS NOT NULL '.
     'AND s.patient_key IS NOT NULL '.
-    'AND s.availability=1 '.
+    'AND (s.availability=1 OR s.invalid=0) '.
     'AND d.status="%s"', DB_PREFIX, $host_item['id'], $STATUS );
 
   $deployment_list = $db_salix->get_all( $sql );
@@ -273,7 +273,7 @@ foreach( $host_list as $host_item )
         'JOIN scan_type t ON t.id=s.scan_type_id '.
         'JOIN %scenozo.participant p ON p.id=b.participant_id '.
         'WHERE h.id=%d '.
-        'AND availability=1 '.
+        'AND (availability=1 OR invalid=0) '.
         'AND type="%s" '.
         'AND side="%s" '.
         'AND uid="%s" '.

--- a/aux/receive_exports
+++ b/aux/receive_exports
@@ -103,7 +103,7 @@ foreach( $host_list as $host_item )
     '  GROUP BY participant_id '.
     ') AS x ON x.participant_id=b.participant_id '.
     'WHERE status = "completed" '.
-    'AND s.availability=1 '.
+    'AND s.invalid=0 '.
     'AND type="hip" '.
     'AND s.scan_datetime IS NOT NULL '.
     'AND h.id=%d '.
@@ -160,6 +160,7 @@ foreach( $host_list as $host_item )
     '  WHEN type="hip" THEN "HIP" '.
     '  WHEN type="spine" THEN "LSPINE" '.
     '  WHEN type="lateral" THEN "LSPINE" '.
+    '  WHEN type="wbody" THEN "BMD" '.
     '  ELSE "NA" '.
     'END AS body_part, '.
     'd.id AS deployment_id, '.
@@ -181,7 +182,7 @@ foreach( $host_list as $host_item )
     '  GROUP BY participant_id '.
     ') AS x ON x.participant_id=b.participant_id '.
     'WHERE status = "completed" '.
-    'AND s.availability=1 '.
+    'AND s.invalid=0 '.
     'AND type="hip" '.
     'AND s.scan_datetime IS NOT NULL '.
     'AND h.id=%d '.


### PR DESCRIPTION
- availability column in apex_scan refers to Opal storage
  while invalid column in apex_scan refers to correct identity/ownership
- scans recovered from site archives (P and R files) can be unavailable
  in Opal and yet be have an invalid status of 0 when imported on an Apex host
- ensure cron processing inludes these recovered scans